### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -58,12 +58,21 @@
       {
         "url": "https://oauth.accounting.sage.com/.*",
         "methods": ["POST"],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {
+          "client_id": {
+            "body": ["client_id"]
+          },
+          "client_secret": {
+            "body": ["client_secret"]
+          }
+        }
       },
       {
         "url": "https://api.accounting.sage.com/v3.1/.*",
         "methods": ["GET", "POST", "PUT"],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {}
       }
     ]
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,7 +21,7 @@ export const placeholders = {
   REFRESH_TOKEN: `[user[${REFRESH_TOKEN_PATH}]]`,
   CLIENT_ID: "__client_id__",
   CLIENT_SECRET: "__client_secret__",
-};
+} as const;
 
 export const DEFAULT_ERROR = "There was an error!"
 


### PR DESCRIPTION
This pull request introduces improvements to configuration and type safety for API integration settings. The main changes are the addition of a new `settingsInjection` property in `manifest.json` for injecting sensitive credentials into the request body, and a minor update to enforce type safety in the `placeholders` object.

Configuration enhancements for credential injection:

* Added a `settingsInjection` property to the Sage OAuth API entry in `manifest.json`, specifying how `client_id` and `client_secret` should be injected into the request body.
* Added an empty `settingsInjection` object to the Sage Accounting API entry in `manifest.json` to maintain consistency and future extensibility.

Type safety improvement:

* Marked the `placeholders` object in `src/constants.ts` as `const` using TypeScript's `as const` assertion, ensuring stronger type safety for its values.

## Summary by Sourcery

Introduce settingsInjection configuration in the app proxy manifest to control credential injection and strengthen placeholder type safety using TypeScript's as const assertion.

New Features:
- Add settingsInjection property in manifest.json to configure injection of client_id and client_secret into request bodies and include an empty settingsInjection for future extensibility

Enhancements:
- Enforce const typing on placeholders object in constants.ts for stronger TypeScript type safety